### PR TITLE
Add backup command

### DIFF
--- a/lib/gitlabomni_manage_tools/command.rb
+++ b/lib/gitlabomni_manage_tools/command.rb
@@ -67,5 +67,10 @@ module GitLabOmnibusManage
     def notify_cronjob
       command_notify_cronjob
     end
+
+    desc 'backup [options]', 'backup command'
+    def backup
+      command_backup
+    end
   end
 end

--- a/lib/gitlabomni_manage_tools/commands/backup.rb
+++ b/lib/gitlabomni_manage_tools/commands/backup.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module GitLabOmnibusManage
+  module SubCommands
+    def command_backup
+      `gitlab-rake#{ options[:quiet] ? ' --quiet' : '' } gitlab:backup:create`
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+$thor_runner = true # rubocop:disable Style/GlobalVars
+
 require 'rspec'
 require 'simplecov'
 


### PR DESCRIPTION
And disable `warning: global variable `$thor_runner' not initialized` on tests.

Also see: https://docs.gitlab.com/ee/raketasks/backup_restore.html#creating-a-backup-of-the-gitlab-system