### PR TITLE
Support disable TLS and add update index command

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,9 @@ Style/Documentation:
 Style/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
+Style/IfUnlessModifier:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - '*.gemspec'

--- a/lib/gitlabomni_manage_tools/archpkg/debian.rb
+++ b/lib/gitlabomni_manage_tools/archpkg/debian.rb
@@ -38,19 +38,29 @@ module GitLabOmnibusManage
         DebianUtil.apt_available_version(PKG_NAME)
       end
 
-      def update_command(options = {})
+      def update_index_command(options = {})
         update_args = []
-        upgrade_args = []
 
         if options[:quiet]
           update_args.push('-qq')
+        end
+
+        <<~COMMAND
+          apt-get update #{update_args.join(' ')}
+        COMMAND
+          .strip
+      end
+
+      def update_command(options = {})
+        upgrade_args = []
+
+        if options[:quiet]
           upgrade_args.push('-qq')
         end
 
         upgrade_args.push('-y') if options[:yes]
 
         <<~COMMAND
-          apt-get update #{update_args.join(' ')}
           apt-get install #{upgrade_args.join(' ')} gitlab-ce
         COMMAND
           .strip

--- a/lib/gitlabomni_manage_tools/command.rb
+++ b/lib/gitlabomni_manage_tools/command.rb
@@ -59,6 +59,13 @@ module GitLabOmnibusManage
       command_update
     end
 
+    desc 'update-index [options]', 'update package index'
+    method_option :quiet, type: :boolean, default: false,
+      aliases: [:q], desc: 'quiet updating'
+    def update_index
+      command_update_index
+    end
+
     desc 'notify-cronjob [options]', 'notify cron job command'
     method_option :mailto, type: :string,
       desc: 'address for mail to'

--- a/lib/gitlabomni_manage_tools/commands/update_index.rb
+++ b/lib/gitlabomni_manage_tools/commands/update_index.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative '../util/base'
+
+module GitLabOmnibusManage
+  module SubCommands
+    module UpdateIndexCommand
+      module_function
+
+      def update_index(pkg, options)
+        pkg.update_index_command(
+          quiet: options[:quiet]
+        ).split("\n").each do |command|
+          system(command)
+        end
+      end
+    end
+
+    def command_update_index
+      UpdateIndexCommand.update_index(@pkg, options)
+    end
+  end
+end

--- a/lib/gitlabomni_manage_tools/config.rb
+++ b/lib/gitlabomni_manage_tools/config.rb
@@ -42,6 +42,7 @@ module GitLabOmnibusManage
             'port' => 25,
             'from' => "gitlab-manage@#{hostname}",
             'to' => "root@#{hostname}",
+            'disable_tls' => false,
             'show_diff' => true,
             'use_primitive_command' => false
           }
@@ -66,6 +67,7 @@ module GitLabOmnibusManage
             port: datas['mail']['port'],
             from: datas['mail']['from'],
             to: datas['mail']['to'],
+            disable_tls: datas['mail']['disable_tls'],
             show_diff: datas['mail']['show_diff'],
             use_primitive_command: datas['mail']['use_primitive_command']
           }
@@ -95,6 +97,10 @@ module GitLabOmnibusManage
 
     def mail_to
       @mail[:to]
+    end
+
+    def mail_disable_tls
+      @mail[:disable_tls]
     end
 
     def mail_show_diff


### PR DESCRIPTION
Please, support disable TLS option.  `mail` library sends by SMTP over STARTTLS on default: https://github.com/mikel/mail/blob/master/lib/mail/network/delivery_methods/smtp.rb#L87

And, currently, `notify-cronjob` command cannot get latest package information.  This command gets cached package information and it was downloaded by recent `apt update`.  So, `notify-cronjob` command must update package index then check available version.
Moreover, `update` command is currently also update index.  However, it is dangerous because we may upgrade `gitlab-ce` to unknown version when GitLab would release new versions after we would be received notification by `gitlab-manage`.  So, we should stop update index when upgrade `gitlab-ce`.
